### PR TITLE
Merge recent version to main.

### DIFF
--- a/mcmc.py
+++ b/mcmc.py
@@ -1848,7 +1848,7 @@ def run_mcmc(
     def prior(cube, ndim, nparams):
         if covariance:
 
-            if M_knee and not sigma_uv:
+            if M_knee and not sigma_uv and not sigma_sfr_10_explicit:
                 # cov_mat = np.loadtxt(
                 #     '/home/inikolic/projects/UVLF_FMs/priors/cov_matr_Mknee.txt'
                 # ) * 4.0

--- a/mcmc.py
+++ b/mcmc.py
@@ -83,7 +83,12 @@ class LikelihoodAngBase():
             self.p1 = p1
             self.p1_z7 = p1_z7
             self.p1_z5_5 = p1_z5_5
-
+        if hmf_choice=="custom":
+            hmf_model = "ST",
+            hmf_params = {"a": 0.73, "p": 0.175, "A": 0.353}
+        else:
+            hmf_model = hmf_choice
+            hmf_params = {}
         fid_params = {
             'p1':p1,
             'zmin': 0,
@@ -95,7 +100,8 @@ class LikelihoodAngBase():
             'hod_model': My_HOD,
             'tracer_concentration_model': hm.concentration.Duffy08,
             'tracer_profile_model': hm.profiles.NFW,
-            'hmf_model': hmf_choice,
+            'hmf_model': hmf_model,
+            'hmf_params': hmf_params,
             'bias_model': "Tinker10",
             'transfer_model': "EH",
             'exclusion_model': "Sphere",
@@ -264,13 +270,25 @@ class LikelihoodUVLFBase:
             slope_SFR=False
     ):
         self.z = z
-        self.hmf_loc = hmf.MassFunction(
-            z=z,
-            Mmin=5,
-            Mmax=19,
-            dlog10m=0.05,
-            hmf_model=hmf_choice
-        )
+        if hmf_choice=="custom":
+            self.hmf_loc = hmf.MassFunction(
+                z=z,
+                Mmin=5,
+                Mmax=19,
+                dlog10m=0.05,
+                cosmo_model=cosmo,
+                hmf_model="ST",
+                hmf_params={"a": 0.73, "p": 0.175, "A": 0.353},
+                transfer_model="EH",
+            )
+        else:
+            self.hmf_loc = hmf.MassFunction(
+                z=z,
+                Mmin=5,
+                Mmax=19,
+                dlog10m=0.05,
+                hmf_model=hmf_choice
+            )
         self.params = params
         self.sigma_sfr_10_explicit = sigma_sfr_10_explicit
         self.sigma_uv = sigma_uv

--- a/mcmc.py
+++ b/mcmc.py
@@ -963,7 +963,10 @@ def run_mcmc(
             )
         else:
             bpass_read = bpass_loader()
-        vect_func = np.vectorize(bpass_read.get_UV)
+        if sigma_sfr_10_explicit:
+            vect_func = np.vectorize(bpass_read.get_UV_sfr10)
+        else:
+            vect_func = np.vectorize(bpass_read.get_UV)
     else:
         bpass_read = None
         vect_func = None

--- a/mcmc.py
+++ b/mcmc.py
@@ -956,7 +956,8 @@ def run_mcmc(
 
     if uvlf and use_BPASS:
         print(script_dir)
-        if script_dir == "/groups/astro/ivannik/programs/JWST-Inference":
+        string_Tycho = "/groups/astro/ivannik/programs/JWST-Inference"
+        if script_dir[:10] == string_Tycho[:10]:
             bpass_read = bpass_loader(
                 filename='/groups/astro/ivannik/programs/Stochasticity_sampler/BPASS/spectra-bin-imf135_300.a+00.',
             )

--- a/mcmc.py
+++ b/mcmc.py
@@ -357,10 +357,14 @@ class LikelihoodUVLFBase:
         else:
             slope_SFR = dic_params["slope_SFR"]
 
-        if "sigma_SFR_10" not in dic_params:
-            sigma_SFR_10 = 0.2
-        else:
+        # Accept both the new parameter name `sigma_sfr_10` and the legacy
+        # name `sigma_SFR_10`, preferring the new one if both are present.
+        if "sigma_sfr_10" in dic_params:
+            sigma_SFR_10 = dic_params["sigma_sfr_10"]
+        elif "sigma_SFR_10" in dic_params:
             sigma_SFR_10 = dic_params["sigma_SFR_10"]
+        else:
+            sigma_SFR_10 = 0.2
 
         lnL = 0
         if use_BPASS:

--- a/mcmc.py
+++ b/mcmc.py
@@ -426,7 +426,9 @@ class LikelihoodUVLFBase:
                     SFH_samp=sfr_samp_inst,
                     M_knee=M_knee,
                     sigma_sfr10=sigma_SFR_10,
-                    mass_dependent_sfr10=self.mass_dependent_sigma_uv, #need to develop a flag for that
+                    # TODO: introduce a dedicated flag for mass-dependent SFR10 scatter
+                    # and thread it through CLI/prior validation. Until then, use a fixed default.
+                    mass_dependent_sfr10=False,
                 )
             else:
                 preds = UV_calc_BPASS(

--- a/src/models/Mason15.py
+++ b/src/models/Mason15.py
@@ -15,6 +15,12 @@ def pMuv_Mh(Muv, logMh, Muv_Mh_dict, sigmaUV_a=-0.34, sigmaUV_b=0.42, Muv_add=0,
     a = −0.34 and b = 0.42,
     """
     sigmaUV = sigmaUV_a * (logMh - 12) + sigmaUV_b
+    # Ensure sigmaUV is strictly positive to define a valid Gaussian PDF
+    sigmaUV_floor = 1e-3
+    if np.isscalar(sigmaUV):
+        sigmaUV = max(sigmaUV, sigmaUV_floor)
+    else:
+        sigmaUV = np.maximum(sigmaUV, sigmaUV_floor)
 
     # Get the Muv-Mh relation for the given redshift
     Muv_Mh_med = np.array(

--- a/src/models/Mason15.py
+++ b/src/models/Mason15.py
@@ -1,0 +1,67 @@
+"""
+A module defining model predictions from Mason+15 (and Mason+23, Nikolic+26) model.
+
+The module includes functions that process the input parameters and returns UVLF.
+
+"""
+
+import hmf
+import numpy as np
+
+
+def pMuv_Mh(Muv, logMh, Muv_Mh_dict, sigmaUV_a=-0.34, sigmaUV_b=0.42, Muv_add=0, return_med_sigma=False):
+    """
+    sigmaUV (Mh) = a (log Mh - 12) + b.
+    a = −0.34 and b = 0.42,
+    """
+    sigmaUV = sigmaUV_a * (logMh - 12) + sigmaUV_b
+
+    # Get the Muv-Mh relation for the given redshift
+    Muv_Mh_med = np.array(
+        [Muv_from_logMh(np.round(np.float64(lM), 1), Muv_Mh_dict, use_scatter=False, dust=True) for lM in
+         logMh]) + Muv_add
+
+    if return_med_sigma:
+        return Muv_Mh_med, sigmaUV
+
+    else:
+        # Calculate the probability density function (PDF) of Muv given logMh
+        pdf = (1 / (np.sqrt(2 * np.pi) * sigmaUV[:, None])) * np.exp(
+            -0.5 * ((Muv - Muv_Mh_med[:, None]) / sigmaUV[:, None]) ** 2)
+
+        return pdf
+
+def Muv_from_logMh(logMh, Muv_Mh_dict, use_scatter=True, sigmaUV=0.3, dust=False):
+    if use_scatter:
+        scatter = np.random.normal(0, sigmaUV)
+    else:
+        scatter = 0
+    if dust:
+        return Muv_Mh_dict[logMh][1] + scatter
+    return Muv_Mh_dict[logMh][0] + scatter
+
+def calculate_uvlf(Muv_shift, sigma_UV_a, sigma_UV_b , mf = None, Muv_grid = None, z = None):
+    if z==None:
+        z = 10.5
+    if mf == None:
+        mf = hmf.MassFunction(z=10.5)
+    if Muv_grid == None:
+        Muv_grid = np.linspace(-25, -13, 100)
+
+    if z==10.5:
+        Muv_Mh_file = '/groups/astro/ivannik/notebooks/clustering_project/Muv_Mh_z=10.txt'
+        Muv_Mh = np.genfromtxt(Muv_Mh_file, dtype=None, names=True)
+        Muv_Mh_dict = {Muv_Mh['logMh'][i]: [Muv_Mh['Muv'][i], Muv_Mh['Muv_dust'][i]] for i in range(len(Muv_Mh))}
+
+
+    pmuvmh = pMuv_Mh(Muv_grid, np.log10(mf.m), Muv_Mh_dict, sigmaUV_a=sigma_UV_a, sigmaUV_b=sigma_UV_b, Muv_add=Muv_shift)
+    UVLF_stochier = np.trapezoid(pmuvmh.T * mf.dndm, mf.m, axis=1)
+    return UVLF_stochier
+
+class Mason15(object):
+    def __init__(self, z=10.5, ):
+        self.z = z
+
+    def calculate_UVLF(self, Muv_shift, sigma_UV_a, sigma_UV_b):
+        UVLF_pred = calculate_uvlf(Muv_shift, sigma_UV_a, sigma_UV_b)
+        return UVLF_pred

--- a/src/models/Mason15.py
+++ b/src/models/Mason15.py
@@ -47,11 +47,11 @@ def Muv_from_logMh(logMh, Muv_Mh_dict, use_scatter=True, sigmaUV=0.3, dust=False
     return Muv_Mh_dict[logMh][0] + scatter
 
 def calculate_uvlf(Muv_shift, sigma_UV_a, sigma_UV_b , mf = None, Muv_grid = None, z = None):
-    if z==None:
+    if z is None:
         z = 10.5
-    if mf == None:
+    if mf is None:
         mf = hmf.MassFunction(z=10.5)
-    if Muv_grid == None:
+    if Muv_grid is None:
         Muv_grid = np.linspace(-25, -13, 100)
 
     if z==10.5:

--- a/uvlf.py
+++ b/uvlf.py
@@ -1297,12 +1297,18 @@ def UV_calc_numba_sfr10(
     sfr10_grid = (10 ** sfr_map_grid)[:, None] * (10 ** x_map_grid)[None, :]  # (Nsfr_map, Nx_map)
     # Evaluate mapping: muuv_map[sfr_i, x_j] = MUV_mean(SFR=sfr_i, SFR10=sfr10_ij)
     # You can compute luminosity then convert to Muv:
-    F_UVs = np.array(
-        [
-            vect_func(Zs, msss, 10 ** sfr_map_grid, z=z, SFH_samp=SFH_samp, sfr_10=sfr10_grid[:, i]) for i in
-            range(1000)
-        ]
-    ).T
+    Nsfr_map = sfr_map_grid.size
+    Nx_map = x_map_grid.size
+    F_UVs = np.empty((Nsfr_map, Nx_map))
+    for i in range(Nsfr_map):
+        F_UVs[i, :] = vect_func(
+            Zs[i],
+            msss[i],
+            10 ** sfr_map_grid[i],
+            z=z,
+            SFH_samp=SFH_samp,
+            sfr_10=sfr10_grid[i],
+        )
     muuv_map = Muv_Luv(F_UVs * 3.846e33)  # (Nsfr_map, Nx_map)
 
     if mass_dependent_sfr10:

--- a/uvlf.py
+++ b/uvlf.py
@@ -1092,6 +1092,15 @@ def bilinear_interp_regular(xgrid, ygrid, F, x, y):
     # avoid divide by zero
     tx = 0.0 if x1 == x0 else (x - x0) / (x1 - x0)
     ty = 0.0 if y1 == y0 else (y - y0) / (y1 - y0)
+    # clamp interpolation parameters to [0, 1] to avoid extrapolation
+    if tx < 0.0:
+        tx = 0.0
+    elif tx > 1.0:
+        tx = 1.0
+    if ty < 0.0:
+        ty = 0.0
+    elif ty > 1.0:
+        ty = 1.0
     f00 = F[i,   j  ]
     f10 = F[i+1, j  ]
     f01 = F[i,   j+1]

--- a/uvlf.py
+++ b/uvlf.py
@@ -1059,7 +1059,6 @@ def apply_dust_to_uvlf(Mint, phi_int, gimme_dust, Mobs_grid=None):
         return Mobs_grid, phi_obs_grid
 
 
-INV_SQRT2PI = 0.3989422804014327
 @njit(fastmath=True)
 def _find_interval(xgrid, x):
     # returns i such that xgrid[i] <= x < xgrid[i+1], clamped

--- a/uvlf.py
+++ b/uvlf.py
@@ -1321,9 +1321,9 @@ def UV_calc_numba_sfr10(
     muuv_map = Muv_Luv(F_UVs * 3.846e33)  # (Nsfr_map, Nx_map)
 
     if mass_dependent_sfr10:
-        sigma_sfr10_var = linear_model_sfr10((msss, z), mass_dependent_sfr10)
+        sigma_sfr10_var = linear_model_sfr10((msss, z), sigma_sfr10)
     else:
-        sigma_sfr10_var = mass_dependent_sfr10 * np.ones(np.shape(msss))
+        sigma_sfr10_var = sigma_sfr10 * np.ones(np.shape(msss))
     sigma_SFMS_var = sigma_SFR_variable(msss, norm=sigma_SFMS_norm,
                                         a_sig_SFR=a_sig_SFR)
     uvlf = uvlf_fast_einsum_sfr10version(
@@ -1337,7 +1337,7 @@ def UV_calc_numba_sfr10(
         sfr_map_grid,
         x_map_grid,
         muuv_map,
-        sigma_x_of_sfr_fn=lambda x: sigma_sfr10,
+        sigma_x_of_sfr_fn=lambda x: np.interp(x, sfr_map_grid, sigma_sfr10_var),
         Nsfr=10_000,
         Nmstar=10_000,
         Nmh=10_000,

--- a/uvlf.py
+++ b/uvlf.py
@@ -481,7 +481,7 @@ class bpass_loader:
         UV_final = float(BSpline(*s)(metal))
         return UV_final
 
-    def get_UV_sfr10(self, metal, Mstar, SFR, z, SFH_samp=None, sfr_10=True):
+    def get_UV_sfr10(self, metal, Mstar, SFR, z, SFH_samp=None, sfr_10=0.0):
         """
         Function returs the specific luminosity at 1500 angstroms averaged over
         100 angstroms.


### PR DESCRIPTION
- [x] Fix `mass_dependent_sfr10` logic in `UV_calc_numba_sfr10` — use `sigma_sfr10` as the base value in both branches (mirroring `UV_calc_numba`)
- [x] Wire `sigma_sfr10_var` into `sigma_x_of_sfr_fn` via interpolation so it's actually used in the Gauss-Hermite integration